### PR TITLE
feat: center-based stage zoom and scaling

### DIFF
--- a/src/components/Stage.vue
+++ b/src/components/Stage.vue
@@ -1,24 +1,50 @@
 <script setup>
+import { ref, computed, onMounted } from 'vue'
 import { useLayersStore } from '../stores/layers.js'
 import { useStageStore } from '../stores/stage.js'
 import Layer from './Layer.vue'
 
+const container = ref(null)
 const layersStore = useLayersStore()
 const stageStore = useStageStore()
 
+const stageSize = computed(() => {
+  const widths = layersStore.layers.map((l) => l.width)
+  const heights = layersStore.layers.map((l) => l.height)
+  return { width: Math.max(...widths), height: Math.max(...heights) }
+})
+
+onMounted(() => {
+  const rect = container.value.getBoundingClientRect()
+  const containScale = Math.min(
+    rect.width / stageSize.value.width,
+    rect.height / stageSize.value.height,
+  )
+  const minScale = containScale * 0.5
+  stageStore.setContainScale(containScale)
+  stageStore.setMinScale(minScale)
+  stageStore.setScale(containScale)
+  stageStore.setOffset({
+    x: (rect.width - stageSize.value.width * containScale) / 2,
+    y: (rect.height - stageSize.value.height * containScale) / 2,
+  })
+})
+
 function onWheel(e) {
+  const rect = container.value.getBoundingClientRect()
   if (e.ctrlKey) {
     e.preventDefault()
     const delta = -e.deltaY * 0.001
-    stageStore.zoom(delta)
+    const point = { x: e.clientX - rect.left, y: e.clientY - rect.top }
+    stageStore.zoom(delta, point, rect, stageSize.value)
   } else {
-    stageStore.pan(-e.deltaX, -e.deltaY)
+    stageStore.pan(-e.deltaX, -e.deltaY, rect, stageSize.value)
   }
 }
 </script>
 
 <template>
-  <div class="w-full h-full overflow-hidden bg-gray-100" @wheel="onWheel">
+  <div ref="container" class="w-full h-full overflow-hidden bg-gray-100" @wheel="onWheel">
     <svg
       class="w-full h-full"
       :style="{ transform: `translate(${stageStore.offset.x}px, ${stageStore.offset.y}px) scale(${stageStore.scale})` }"

--- a/src/stores/stage.js
+++ b/src/stores/stage.js
@@ -4,20 +4,60 @@ export const useStageStore = defineStore('stage', {
   state: () => ({
     scale: 1,
     offset: { x: 0, y: 0 },
+    minScale: 0.1,
+    containScale: 1,
   }),
   actions: {
-    zoom(delta) {
-      this.scale = Math.min(5, Math.max(0.1, this.scale + delta))
+    zoom(delta, point, rect, stageSize) {
+      const newScale = Math.min(5, Math.max(this.minScale, this.scale + delta))
+      const scaleFactor = newScale / this.scale
+      this.offset.x = point.x - scaleFactor * (point.x - this.offset.x)
+      this.offset.y = point.y - scaleFactor * (point.y - this.offset.y)
+      this.scale = newScale
+      this._keepInBounds(rect, stageSize)
     },
-    pan(dx, dy) {
+    pan(dx, dy, rect, stageSize) {
       this.offset.x += dx
       this.offset.y += dy
+      this._keepInBounds(rect, stageSize)
     },
     setScale(scale) {
       this.scale = scale
     },
     setOffset(offset) {
       this.offset = offset
+    },
+    setMinScale(scale) {
+      this.minScale = scale
+    },
+    setContainScale(scale) {
+      this.containScale = scale
+    },
+    _keepInBounds(rect, stageSize) {
+      const stageWidth = stageSize.width * this.scale
+      const stageHeight = stageSize.height * this.scale
+      let x = this.offset.x
+      let y = this.offset.y
+
+      if (stageWidth >= rect.width) {
+        const minX = rect.width - stageWidth
+        const maxX = 0
+        x = Math.min(maxX, Math.max(minX, x))
+      }
+      if (stageHeight >= rect.height) {
+        const minY = rect.height - stageHeight
+        const maxY = 0
+        y = Math.min(maxY, Math.max(minY, y))
+      }
+
+      const centerX = (rect.width - stageWidth) / 2
+      const centerY = (rect.height - stageHeight) / 2
+      const range = this.containScale - this.minScale
+      const t = range > 0 ? Math.min(1, Math.max(0, (this.scale - this.minScale) / range)) : 1
+      x = x * t + centerX * (1 - t)
+      y = y * t + centerY * (1 - t)
+
+      this.offset = { x, y }
     },
   },
 })


### PR DESCRIPTION
## Summary
- allow zooming around the pointer
- track minScale and containScale in the stage store
- initialize stage centered at containScale and smoothly recenter near minScale

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d5b2c5c832c9992f51fe96b2f0e